### PR TITLE
feat: Save all eventbus messages to s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# da-tre-tf-module-tre-out-to-s3
+# da-tre-tf-module-da-eventbus-to-s3
 A module to dump messages from tre-out to S3 with a filter and partitioning rules
 
 Current Config:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,2 @@
 # da-tre-tf-module-da-eventbus-to-s3
-A module to dump messages from tre-out to S3 with a filter and partitioning rules
-
-Current Config:
-
-Filter ```uk.gov.nationalarchives.tre.messages.judgmentpackage.available.JudgmentPackageAvailable```
-
-and partition them to S3 as:
-
-```<bucket>/judgmentpackage.available.JudgmentPackageAvailable/originator/reference/<the raw message>```
-
-e.g. ```judgmentpackage.available.JudgmentPackageAvailable/ABC/ABC-123```
+A module to dump all messages from da-eventbus to s3. The module is subscribed to the eventbus in `da-tre-terraform-environments`.

--- a/main.tf
+++ b/main.tf
@@ -122,27 +122,8 @@ resource "aws_kinesis_firehose_delivery_stream" "sns_firehose_eventbus_capture_s
     bucket_arn      = aws_s3_bucket.s3_bucket_eventbus_capture.arn
     buffer_interval = 60
     buffer_size     = 64
-
-    dynamic_partitioning_configuration {
-      enabled = "true"
-    }
-    prefix              = "!{partitionKeyFromQuery:originator}/!{partitionKeyFromQuery:reference}/!{partitionKeyFromQuery:executionId}/"
+    
+    prefix              = "messages/"
     error_output_prefix = "errors/!{firehose:error-output-type}/"
-
-    processing_configuration {
-      enabled = true
-
-      processors {
-        type = "MetadataExtraction"
-        parameters {
-          parameter_name  = "MetadataExtractionQuery"
-          parameter_value = "{executionId:.properties.executionId,originator:.parameters.originator,reference:.parameters.reference}"
-        }
-        parameters {
-          parameter_name  = "JsonParsingEngine"
-          parameter_value = "JQ-1.6"
-        }
-      }
-    }
   }
 }

--- a/output.tf
+++ b/output.tf
@@ -1,5 +1,5 @@
-output "sns_firehose_tre_out_capture_s3_arn" {
-  value       = aws_kinesis_firehose_delivery_stream.sns_firehose_tre_out_capture_s3.arn
+output "sns_firehose_eventbus_capture_s3_arn" {
+  value       = aws_kinesis_firehose_delivery_stream.sns_firehose_eventbus_capture_s3.arn
   description = "ARN of the firehose stream to delivers to S3"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "tre_permission_boundary_arn" {
   type        = string
 }
 
-variable "tre_out_topic_arn" {
-  description = "ARN of the output topic to subscribe to"
+variable "eventbus_topic_arn" {
+  description = "ARN of the event bus topic to subscribe to"
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,8 +12,3 @@ variable "tre_permission_boundary_arn" {
   description = "ARN of the TRE permission boundary policy"
   type        = string
 }
-
-variable "eventbus_topic_arn" {
-  description = "ARN of the event bus topic to subscribe to"
-  type        = string
-}


### PR DESCRIPTION
Dump messages from eventbus instead of tre out, which is being deprecated. Remove partitioning for now, @TNAemmaPea has made backlog ticket to refine how we do this.