### PR TITLE
DTE-889: partition firehose

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -122,8 +122,27 @@ resource "aws_kinesis_firehose_delivery_stream" "sns_firehose_eventbus_capture_s
     bucket_arn      = aws_s3_bucket.s3_bucket_eventbus_capture.arn
     buffer_interval = 60
     buffer_size     = 64
-    
-    prefix              = "messages/"
+
+    dynamic_partitioning_configuration {
+      enabled = "true"
+    }
+
+    prefix              = "messages/!{timestamp:yyyy-MM-dd}/!{partitionKeyFromQuery:reference}/"
     error_output_prefix = "errors/!{firehose:error-output-type}/"
+
+    processing_configuration {
+      enabled = "true"
+      processors {
+        type = "MetadataExtraction"
+        parameters {
+          parameter_name  = "JsonParsingEngine"
+          parameter_value = "JQ-1.6"
+        }
+        parameters {
+          parameter_name  = "MetadataExtractionQuery"
+          parameter_value = "{reference:(.parameters.reference // \"_no-reference\")}"
+        }
+      }
+    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -132,6 +132,11 @@ resource "aws_kinesis_firehose_delivery_stream" "sns_firehose_eventbus_capture_s
 
     processing_configuration {
       enabled = "true"
+
+      processors {
+        type = "AppendDelimiterToRecord"
+      }
+
       processors {
         type = "MetadataExtraction"
         parameters {


### PR DESCRIPTION
partitions by `prefix = "messages/!{timestamp:yyyy-MM-dd}/!{partitionKeyFromQuery:reference}/"`
so date comes from system and if reference is missing the JQ falls back to `_no-reference` so we find the msgs there